### PR TITLE
[어드민] 데이터베이스 접근 로직 테스트 정의

### DIFF
--- a/src/main/java/com/fastcampus/projectboardadmin/config/JpaConfig.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/config/JpaConfig.java
@@ -1,0 +1,27 @@
+package com.fastcampus.projectboardadmin.config;
+
+import com.fastcampus.projectboardadmin.dto.security.BoardAdminPrincipal;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Optional;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaConfig {
+
+    @Bean
+    public AuditorAware<String> auditorAware() {
+        return () -> Optional.ofNullable(SecurityContextHolder.getContext())//SecurityContextHolder - 세큐리티의 모든 정보를 가지는 클래스
+                .map(SecurityContext::getAuthentication)//인증정보 확인
+                .filter(Authentication::isAuthenticated)//인증 되었는지 확인
+                .map(Authentication::getPrincipal)//로그인 정보 가져오기
+                .map(BoardAdminPrincipal.class::cast)//커스텀 principal로 캐스트
+                .map(BoardAdminPrincipal::getUsername);
+    }
+}

--- a/src/main/java/com/fastcampus/projectboardadmin/repository/UserAccountRepository.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/repository/UserAccountRepository.java
@@ -1,0 +1,7 @@
+package com.fastcampus.projectboardadmin.repository;
+
+import com.fastcampus.projectboardadmin.domain.UserAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserAccountRepository extends JpaRepository<UserAccount, String> {
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,7 @@
+-- 유저
+insert into user_account (user_id, user_password, role_types, nickname, email, memo, create_at, create_by, modified_at, modified_by) values
+('jinwoo', '{noop}asdf1234', 'ADMIN', 'Jinwoo', 'jinwoo@mail.com', 'I am Jinwoo.', now(), 'jinwoo', now(), 'jinwoo'),
+('mark', '{noop}asdf1234', 'MANAGER', 'Mark', 'mark@mail.com', 'I am Mark.', now(), 'jinwoo', now(), 'jinwoo'),
+('susan', '{noop}asdf1234', 'MANAGER,DEVELOPER', 'Susan', 'Susan@mail.com', 'I am Susan.', now(), 'jinwoo', now(), 'jinwoo'),
+('jim', '{noop}asdf1234', 'USER', 'Jim', 'jim@mail.com', 'I am Jim.', now(), 'jinwoo', now(), 'jinwoo')
+;

--- a/src/test/java/com/fastcampus/projectboardadmin/repository/JpaRepositoryTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/repository/JpaRepositoryTest.java
@@ -1,0 +1,101 @@
+package com.fastcampus.projectboardadmin.repository;
+
+import com.fastcampus.projectboardadmin.domain.UserAccount;
+import com.fastcampus.projectboardadmin.domain.constant.RoleType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("JPA 연결 테스트")
+@Import(JpaRepositoryTest.TestJpaConfig.class)
+@DataJpaTest
+class JpaRepositoryTest {
+
+    private final UserAccountRepository userAccountRepository;
+
+    public JpaRepositoryTest(@Autowired UserAccountRepository userAccountRepository) {
+        this.userAccountRepository = userAccountRepository;
+    }
+
+    @DisplayName("회원 정보 select 테스트")
+    @Test
+    void givenUserAccounts_whenSelecting_thenWorksFine() {
+        // Given
+
+
+        // When
+        List<UserAccount> userAccounts = userAccountRepository.findAll();
+
+        // Then
+        assertThat(userAccounts)
+                .isNotNull()
+                .hasSize(4);
+    }
+
+    @DisplayName("회원 정보 insert 테스트")
+    @Test
+    void givenUserAccount_whenInserting_thenWorksFine() {
+        // Given
+        long previousCount = userAccountRepository.count();
+        UserAccount userAccount = UserAccount.of("test", "pw", Set.of(RoleType.DEVELOPER), "email", "nickname", null);
+
+        // When
+        userAccountRepository.save(userAccount);
+
+        // Then
+        assertThat(userAccountRepository.count()).isEqualTo(previousCount + 1);
+    }
+
+    @DisplayName("회원 정보 update 테스트")
+    @Test
+    void givenUserAccountAndRoleType_whenUpdating_thenWorksFine() {
+        // Given
+        UserAccount userAccount = userAccountRepository.getReferenceById("jinwoo");
+        userAccount.addRoleType(RoleType.DEVELOPER);
+        userAccount.addRoleTypes(List.of(RoleType.USER, RoleType.USER));
+        userAccount.removeRoleType(RoleType.ADMIN);
+
+        // When
+        UserAccount updateAccount = userAccountRepository.saveAndFlush(userAccount);
+
+        // Then
+        assertThat(updateAccount)
+                .hasFieldOrPropertyWithValue("userId", "jinwoo")
+                .hasFieldOrPropertyWithValue("roleTypes", Set.of(RoleType.DEVELOPER, RoleType.USER));
+    }
+
+    @DisplayName("회원 정보 delete 테스트")
+    @Test
+    void givenUserAccount_whenDeleting_thenWorksFine() {
+        // Given
+        long previousCount = userAccountRepository.count();
+        UserAccount userAccount = userAccountRepository.getReferenceById("jinwoo");
+
+        // When
+        userAccountRepository.delete(userAccount);
+
+        // Then
+        assertThat(userAccountRepository.count()).isEqualTo(previousCount - 1);
+    }
+
+    @EnableJpaAuditing
+    @TestConfiguration
+    public static class TestJpaConfig{
+        @Bean
+        public AuditorAware<String> auditorAware(){
+            return () -> Optional.of("jinwoo");
+        }
+    }
+}


### PR DESCRIPTION
회원 데이터에 접근할 리포지토리 인터페이스와
jpa auditing 기능을 활성화시킬 `JpaConfig`,
각자 다른 권한을 가진 테스트용 회원 데이터,
crud 쿼리 생성을 확인할 jpa 테스트 작성

This closes #5 