### PR TITLE
[어드민] 뷰 엔드포인트 테스트 정의

### DIFF
--- a/src/main/java/com/fastcampus/projectboardadmin/controller/AdminUserAccountController.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/controller/AdminUserAccountController.java
@@ -1,0 +1,9 @@
+package com.fastcampus.projectboardadmin.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequestMapping("/admin/members")
+@Controller
+public class AdminUserAccountController {
+}

--- a/src/main/java/com/fastcampus/projectboardadmin/controller/ArticleCommentManagementController.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/controller/ArticleCommentManagementController.java
@@ -1,0 +1,9 @@
+package com.fastcampus.projectboardadmin.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequestMapping("/management/article-comments")
+@Controller
+public class ArticleCommentManagementController {
+}

--- a/src/main/java/com/fastcampus/projectboardadmin/controller/ArticleManagementController.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/controller/ArticleManagementController.java
@@ -1,0 +1,9 @@
+package com.fastcampus.projectboardadmin.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequestMapping("/management/articles")
+@Controller
+public class ArticleManagementController {
+}

--- a/src/main/java/com/fastcampus/projectboardadmin/controller/MainController.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/controller/MainController.java
@@ -1,0 +1,8 @@
+package com.fastcampus.projectboardadmin.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+public class MainController {
+}

--- a/src/main/java/com/fastcampus/projectboardadmin/controller/UserAccountManagementController.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/controller/UserAccountManagementController.java
@@ -1,0 +1,9 @@
+package com.fastcampus.projectboardadmin.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequestMapping("/management/user-accounts")
+@Controller
+public class UserAccountManagementController {
+}

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/AdminUserAccountControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/AdminUserAccountControllerTest.java
@@ -1,0 +1,38 @@
+package com.fastcampus.projectboardadmin.controller;
+
+import com.fastcampus.projectboardadmin.config.SecurityConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@DisplayName("View 컨트롤러 - 어드민 회원")
+@Import(SecurityConfig.class)
+@WebMvcTest(AdminUserAccountController.class)
+class AdminUserAccountControllerTest {
+
+    private final MockMvc mvc;
+
+    public AdminUserAccountControllerTest(@Autowired MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+    @DisplayName("[view][get] 어드민 회원 페이지 - 정상 호출")
+    @Test
+    void givenNothing_whenRequestingAdminMembersView_thenReturnsAdminMembersView() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/admin/members"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+                .andExpect(view().name("admin/members"));
+    }
+}

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleCommentManagementControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleCommentManagementControllerTest.java
@@ -1,0 +1,38 @@
+package com.fastcampus.projectboardadmin.controller;
+
+import com.fastcampus.projectboardadmin.config.SecurityConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@DisplayName("View 컨트롤러 - 댓글 관리")
+@Import(SecurityConfig.class)
+@WebMvcTest(ArticleCommentManagementController.class)
+class ArticleCommentManagementControllerTest {
+
+    private final MockMvc mvc;
+
+    public ArticleCommentManagementControllerTest(@Autowired MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+    @DisplayName("[view][get] 댓글 관리 페이지 - 정상 호출")
+    @Test
+    void givenNoting_whenRequestArticleCommentManageView_thenReturnArticleCommentManageView() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/management/article-comments"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+                .andExpect(view().name("management/article-comments"));
+    }
+}

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleManagementControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleManagementControllerTest.java
@@ -1,0 +1,37 @@
+package com.fastcampus.projectboardadmin.controller;
+
+import com.fastcampus.projectboardadmin.config.SecurityConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@DisplayName("View 컨트롤러 - 게시글 관리")
+@Import(SecurityConfig.class)
+@WebMvcTest(ArticleManagementController.class)
+class ArticleManagementControllerTest {
+
+    private final MockMvc mvc;
+
+    public ArticleManagementControllerTest(@Autowired MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+    @DisplayName("[view][get] 게시글 관리 페이지 - 정상 호출")
+    @Test
+    void givenNoting_whenRequestingArticleManagementView_thenReturnsArticleManagementView() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/management/articles"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+                .andExpect(view().name("management/articles"));
+    }
+}

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/MainControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/MainControllerTest.java
@@ -1,0 +1,37 @@
+package com.fastcampus.projectboardadmin.controller;
+
+import com.fastcampus.projectboardadmin.config.SecurityConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@DisplayName("View 루트 컨트롤러")
+@Import(SecurityConfig.class)
+@WebMvcTest(MainController.class)
+class MainControllerTest {
+
+    private  final MockMvc mvc;
+
+    public MainControllerTest(@Autowired MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+    @DisplayName("[view][get] 루트페이지 -> 게시글 관리 페이지 Forwarding")
+    @Test
+    void givenNoting_whenRequestRootView_thenForwardToArticleManageView() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("forward:/management/articles"))
+                .andExpect(forwardedUrl("/management/articles"));
+    }
+}

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/UserAccountManagementControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/UserAccountManagementControllerTest.java
@@ -1,0 +1,38 @@
+package com.fastcampus.projectboardadmin.controller;
+
+import com.fastcampus.projectboardadmin.config.SecurityConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@DisplayName("View 컨트롤러 - 회원 관리")
+@Import(SecurityConfig.class)
+@WebMvcTest(UserAccountManagementController.class)
+class UserAccountManagementControllerTest {
+
+    private final MockMvc mvc;
+
+    public UserAccountManagementControllerTest(@Autowired MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+    @DisplayName("[view][get] 회원 관리 페이지 - 정상 호출")
+    @Test
+    void givenNothing_whenRequestingUserAccountManagementView_thenReturnsUserAccountManagementView() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/management/user-accounts"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+                .andExpect(view().name("management/user-accounts"));
+    }
+}


### PR DESCRIPTION
어드민에서 필요로 한 뷰는 다음 5가지

* 메인 루트 뷰
* 게시글 관리 뷰
* 댓글 관리 뷰
* 회원 관리 뷰
* 어드민 회원 뷰

이에 각 뷰를 담당할 컨트롤러 클래스와
기본적인 최소한의 핸들러 메소드, 뷰 템플릿,
정상적인 뷰 응답 케이스를 간단히 정의하는 컨트롤러 테스트 작성
테스트만 통과하는 정도의 구현이고
실제 비즈니스 로직 구현을 담고 있지 않음

This closes #8 