### PR TITLE
[어드민] 로그인 페이지 만들기

### DIFF
--- a/src/main/java/com/fastcampus/projectboardadmin/config/SecurityConfig.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/config/SecurityConfig.java
@@ -16,6 +16,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
                 .formLogin(withDefaults())
                 .logout(logout -> logout.logoutSuccessUrl("/"))
+                .oauth2Login(withDefaults())
                 .build();
     }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -34,7 +34,7 @@ spring:
             client-secret: ${KAKAO_OAUTH_CLIENT_SECRET}
             authorization-grant-type: authorization_code
             redirect-uri: "{baseUrl}/login/oauth2/code/kakao"
-            client-authentication-method: POST
+            client-authentication-method: client_secret_post
         provider:
           kakao:
             authorization-uri: https://kauth.kakao.com/oauth/authorize

--- a/src/main/resources/templates/layouts/layout-left-aside.th.xml
+++ b/src/main/resources/templates/layouts/layout-left-aside.th.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <thlogic>
   <attr sel="#admin-logo-link" th:href="@{/}" />
-  <attr sel="#user-profile" th:href="@{#}" sec:authorize="isAuthenticated()" sec:authentication="principal.nickname" />
+<!--  <attr sel="#user-profile" th:href="@{#}" sec:authorize="isAuthenticated()" sec:authentication="principal.nickname" />-->
   <attr sel="#management-category" th:classappend="${requestURI.startsWith('/management')} ? 'active'" />
   <!--  <attr sel="#management-category" th:classappend="${#request.requestURI.startsWith('/management')} ? 'active'" />-->
   <attr


### PR DESCRIPTION
버튼 클릭하여 카카오 로그인 페이지를 호출 시도하면
카카오 로그인 페이지로 이동해야 하므로
스프링 시큐리티 oauth 의 기본 기능을 켜서
해당 기능이 반응하도록 함

This closes #18 