### PR TITLE
[어드민] 댓글 관리 페이지 기능 테스트 정의

### DIFF
--- a/src/main/java/com/fastcampus/projectboardadmin/dto/ArticleCommentDto.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/dto/ArticleCommentDto.java
@@ -1,0 +1,19 @@
+package com.fastcampus.projectboardadmin.dto;
+
+import java.time.LocalDateTime;
+
+public record ArticleCommentDto(
+        Long id
+        , Long articleId
+        , UserAccountDto userAccountDto
+        , Long parentCommentId
+        , String content
+        , LocalDateTime createAt
+        , String createBy
+        , LocalDateTime modifiedAt
+        , String modifiedBy
+) {
+    public static ArticleCommentDto of(Long id, Long articleId, UserAccountDto userAccountDto, Long parentCommentId, String content, LocalDateTime createAt, String createBy, LocalDateTime modifiedAt, String modifiedBy) {
+        return new ArticleCommentDto(id, articleId, userAccountDto, parentCommentId, content, createAt, createBy, modifiedAt, modifiedBy);
+    }
+}

--- a/src/main/java/com/fastcampus/projectboardadmin/dto/reponse/ArticleCommentClientResponse.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/dto/reponse/ArticleCommentClientResponse.java
@@ -1,0 +1,46 @@
+package com.fastcampus.projectboardadmin.dto.reponse;
+
+import com.fastcampus.projectboardadmin.dto.ArticleCommentDto;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record ArticleCommentClientResponse(
+        @JsonProperty("_embedded") ArticleCommentClientResponse.Embedded embedded
+        , @JsonProperty("page") ArticleCommentClientResponse.Page page
+) {
+    public static ArticleCommentClientResponse empty(){
+        return new ArticleCommentClientResponse(
+                new ArticleCommentClientResponse.Embedded(List.of())
+                , new ArticleCommentClientResponse.Page(1, 0, 1, 0)
+        );
+    }
+
+    public static ArticleCommentClientResponse of(List<ArticleCommentDto> articleCommentDtos){
+        return new ArticleCommentClientResponse(
+                new ArticleCommentClientResponse.Embedded(articleCommentDtos)
+                , new ArticleCommentClientResponse.Page(articleCommentDtos.size(), articleCommentDtos.size(), 1, 0)
+        );
+    }
+
+    public List<ArticleCommentDto> articles() {
+        return this.embedded.articleCommentDtos;
+    }
+
+    public record Embedded(@JsonProperty("articleComments") List<ArticleCommentDto> articleCommentDtos){}
+
+    /**
+     * api로 받아오는 json데이터의 page안쪽 필드명이 동일하기 때문에 @JsonProperty를 지정해주지 않음.
+     *
+     * @param size
+     * @param totalElements
+     * @param totalPages
+     * @param number
+     */
+    public record Page(
+            int size
+            , long totalElements
+            , int totalPages
+            , int number
+    ){}
+}

--- a/src/main/java/com/fastcampus/projectboardadmin/service/ArticleCommentManagementService.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/service/ArticleCommentManagementService.java
@@ -1,0 +1,24 @@
+package com.fastcampus.projectboardadmin.service;
+
+import com.fastcampus.projectboardadmin.dto.ArticleCommentDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class ArticleCommentManagementService {
+
+    public List<ArticleCommentDto> getArticleComments(){
+        return List.of();
+    }
+
+    public ArticleCommentDto getArticleComment(Long articleId){
+        return null;
+    }
+
+    public void deleteArticleComment(Long articleId){
+
+    }
+}

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleCommentManagementControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleCommentManagementControllerTest.java
@@ -1,16 +1,27 @@
 package com.fastcampus.projectboardadmin.controller;
 
 import com.fastcampus.projectboardadmin.config.SecurityConfig;
+import com.fastcampus.projectboardadmin.domain.constant.RoleType;
+import com.fastcampus.projectboardadmin.dto.ArticleCommentDto;
+import com.fastcampus.projectboardadmin.dto.UserAccountDto;
+import com.fastcampus.projectboardadmin.service.ArticleCommentManagementService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @DisplayName("View 컨트롤러 - 댓글 관리")
@@ -20,6 +31,9 @@ class ArticleCommentManagementControllerTest {
 
     private final MockMvc mvc;
 
+    @MockBean
+    private ArticleCommentManagementService articleCommentManagementService;
+
     public ArticleCommentManagementControllerTest(@Autowired MockMvc mvc) {
         this.mvc = mvc;
     }
@@ -28,11 +42,72 @@ class ArticleCommentManagementControllerTest {
     @Test
     void givenNoting_whenRequestArticleCommentManageView_thenReturnArticleCommentManageView() throws Exception {
         // Given
+        given(articleCommentManagementService.getArticleComments()).willReturn(List.of());
 
         // When & Then
         mvc.perform(get("/management/article-comments"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
-                .andExpect(view().name("management/articleComments"));
+                .andExpect(view().name("management/articleComments"))
+                .andExpect(model().attribute("articleComments", List.of()));
+        then(articleCommentManagementService).should().getArticleComments();
+    }
+
+    @DisplayName("[data][get] 댓글 1개 - 정상 호출")
+    @Test
+    void givenArticleCommentId_whenRequestingArticleComment_thenReturnArticleComment() throws Exception {
+        // Given
+        Long articleCommentId = 1L;
+        ArticleCommentDto articleCommentDto = createArticleCommentDto("내용");
+        given(articleCommentManagementService.getArticleComment(articleCommentId)).willReturn(articleCommentDto);
+
+        // When & Then
+        mvc.perform(get("/management/article-comments/" + articleCommentId))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.id").value(articleCommentId))
+                .andExpect(jsonPath("$.cotent").value(articleCommentDto.content()))
+                .andExpect(jsonPath("$.userAccount.nickname").value(articleCommentDto.userAccountDto().nickname()));
+        then(articleCommentManagementService).should().getArticleComment(articleCommentId);
+    }
+
+    @DisplayName("[view][post] 댓글 삭제 - 정상 호출")
+    @Test
+    void givenArticleCommentId_whenRequestDeleteArticleComment_thenDeleteArticleComment() throws Exception {
+        // Given
+        Long articleCommentId = 1L;
+        willDoNothing().given(articleCommentManagementService).deleteArticleComment(articleCommentId);
+
+        // When & Then
+        mvc.perform(post("/management/article-comments/" + articleCommentId))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(view().name("redirect:/management/article-comments"))
+                .andExpect(redirectedUrl("/management/article-comments"));
+        then(articleCommentManagementService).should().deleteArticleComment(articleCommentId);
+    }
+
+    private ArticleCommentDto createArticleCommentDto(String content) {
+        return ArticleCommentDto.of(
+                1L
+                , 1L
+                , createUserAccountDto()
+                , null
+                , content
+                , LocalDateTime.now()
+                , "Jinwoo"
+                , LocalDateTime.now()
+                , "Jinwoo"
+        );
+    }
+
+    private UserAccountDto createUserAccountDto() {
+        return UserAccountDto.of(
+                "jinwoo"
+                , "pw"
+                , Set.of(RoleType.ADMIN)
+                , "jinwoo@email.com"
+                , "jinwoo"
+                , "memo"
+        );
     }
 }

--- a/src/test/java/com/fastcampus/projectboardadmin/service/ArticleCommentManagementServiceTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/service/ArticleCommentManagementServiceTest.java
@@ -1,10 +1,12 @@
 package com.fastcampus.projectboardadmin.service;
 
 import com.fastcampus.projectboardadmin.domain.constant.RoleType;
+import com.fastcampus.projectboardadmin.dto.ArticleCommentDto;
 import com.fastcampus.projectboardadmin.dto.ArticleDto;
 import com.fastcampus.projectboardadmin.dto.UserAccountDto;
 import com.fastcampus.projectboardadmin.dto.properties.ProjectProperties;
 import com.fastcampus.projectboardadmin.dto.reponse.ArticleClientResponse;
+import com.fastcampus.projectboardadmin.dto.reponse.ArticleCommentClientResponse;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Disabled;
@@ -20,40 +22,39 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.client.MockRestServiceServer;
-import org.springframework.test.web.client.match.MockRestRequestMatchers;
-import org.springframework.web.client.RestTemplate;
 
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
-import static org.springframework.test.web.client.response.MockRestResponseCreators.withTooManyRequests;
 
 @ActiveProfiles("testdb")
-@DisplayName("비즈니스 로직 - 게시글 관리")
-class ArticleManagementServiceTest {
+@DisplayName("비즈니스 로직 - 댓글 관리")
+class ArticleCommentManagementServiceTest {
 
 //    @Disabled("실제 API 호출 결과 관찰용이므로 평상시엔 비활성화")
     @DisplayName("실제 API 호출 테스트")
     @SpringBootTest
     @Nested
     class RealRestTest{
-        private final ArticleManagementService sut;
+        private final ArticleCommentManagementService sut;
 
-        public RealRestTest(@Autowired ArticleManagementService sut) {
+        public RealRestTest(@Autowired ArticleCommentManagementService sut) {
             this.sut = sut;
         }
 
-        @DisplayName("게시글 API를 호출하면, 게시글을 가져온다.")
+        @DisplayName("댓글 API를 호출하면, 댓글을 가져온다.")
         @Test
-        void givenNoting_whenCallingArticleApi_thenReturnArticleList() {
+        void givenNoting_whenCallingArticleCommentsApi_thenReturnArticleCommentsList() {
             // Given
 
             // When
-            List<ArticleDto> result = sut.getArticles();
+            List<ArticleCommentDto> result = sut.getArticleComments();
 
             // Then
             System.out.println(result.stream().findFirst());
@@ -64,94 +65,94 @@ class ArticleManagementServiceTest {
     @DisplayName("API mocking 테스트")
     @EnableConfigurationProperties(ProjectProperties.class)
     @AutoConfigureWebClient(registerRestTemplate = true)
-    @RestClientTest(ArticleManagementService.class)
+    @RestClientTest(ArticleCommentManagementService.class)
     @Nested
     class RestTemplateTest{
 
-        private final ArticleManagementService sut;
+        private final ArticleCommentManagementService sut;
         private final ProjectProperties projectProperties;
         private final MockRestServiceServer server;
         private final ObjectMapper mapper;
 
         @Autowired
-        public RestTemplateTest(ArticleManagementService sut, ProjectProperties projectProperties, MockRestServiceServer server, ObjectMapper mapper) {
+        public RestTemplateTest(ArticleCommentManagementService sut, ProjectProperties projectProperties, MockRestServiceServer server, ObjectMapper mapper) {
             this.sut = sut;
             this.projectProperties = projectProperties;
             this.server = server;
             this.mapper = mapper;
         }
 
-        @DisplayName("게시글 목록 API를 호출하면, 게시글들을 가져온다.")
+        @DisplayName("댓글 API를 호출하면, 댓글을 가져온다.")
         @Test
-        void givenNoting_whenCallingArticleApi_thenReturnArticleList() throws JsonProcessingException {
+        void givenNoting_whenCallingArticleCommentsApi_thenReturnArticleCommentsList() throws JsonProcessingException {
             // Given
-            ArticleDto expectedArticle = createArticleDto("제목", "글");
-            ArticleClientResponse expectedReponse = ArticleClientResponse.of(List.of(expectedArticle));
-            server.expect(requestTo(projectProperties.board().url() + "/api/articles?size=10000"))
+            ArticleCommentDto expectedArticle = createArticleCommentDto("글");
+            ArticleCommentClientResponse expectedReponse = ArticleCommentClientResponse.of(List.of(expectedArticle));
+            server.expect(requestTo(projectProperties.board().url() + "/api/articleComments?size=10000"))
                     .andRespond(withSuccess(
                             mapper.writeValueAsString(expectedReponse)
                             , MediaType.APPLICATION_JSON
                     ));
 
             // When
-            List<ArticleDto> results = sut.getArticles();
+            List<ArticleCommentDto> results = sut.getArticleComments();
 
             // Then
             assertThat(results).first()
                     .hasFieldOrPropertyWithValue("id", expectedArticle.id())
-                    .hasFieldOrPropertyWithValue("title", expectedArticle.title())
+                    .hasFieldOrPropertyWithValue("articleId", expectedArticle.articleId())
                     .hasFieldOrPropertyWithValue("content", expectedArticle.content())
                     .hasFieldOrPropertyWithValue("useAccount.nickname", expectedArticle.userAccountDto().nickname());
             server.verify();
         }
 
-        @DisplayName("게시글 목록 API를 호출하면, 게시글을 가져온다.")
+        @DisplayName("댓글 목록 API를 호출하면, 댓글을 가져온다.")
         @Test
-        void givenNoting_whenCallingArticleApi_thenReturnArticle() throws JsonProcessingException {
+        void givenNoting_whenCallingArticleCommentsApi_thenReturnArticleComments() throws JsonProcessingException {
             // Given
             Long articleId = 1L;
-            ArticleDto expectedArticle = createArticleDto("제목", "글");
-            server.expect(requestTo(projectProperties.board().url() + "/api/articles/" + articleId))
+            ArticleCommentDto expectedArticle = createArticleCommentDto("글");
+            server.expect(requestTo(projectProperties.board().url() + "/api/articleComments/" + articleId))
                     .andRespond(withSuccess(
                             mapper.writeValueAsString(expectedArticle)
                             , MediaType.APPLICATION_JSON
                     ));
 
             // When
-            ArticleDto results = sut.getArticle(articleId);
+            ArticleCommentDto results = sut.getArticleComment(articleId);
 
             // Then
             assertThat(results)
                     .hasFieldOrPropertyWithValue("id", articleId)
-                    .hasFieldOrPropertyWithValue("title", expectedArticle.title())
+                    .hasFieldOrPropertyWithValue("articleId", expectedArticle.articleId())
                     .hasFieldOrPropertyWithValue("content", expectedArticle.content())
                     .hasFieldOrPropertyWithValue("useAccount.nickname", expectedArticle.userAccountDto().nickname());
             server.verify();
         }
 
-        @DisplayName("게시글 목록 API를 호출하면, 게시글을 삭제한다.")
+        @DisplayName("댓글글 목록 API를 호출하면, 댓글을 삭제한다.")
         @Test
-        void givenNoting_whenCallingDeleteArticleApi_thenDeleteArticle() {
+        void givenNoting_whenCallingDeleteArticleCommentsApi_thenDeleteArticle() {
             // Given
             Long articleId = 1L;
-            server.expect(requestTo(projectProperties.board().url() + "/api/articles/" + articleId))
+            server.expect(requestTo(projectProperties.board().url() + "/api/articleComments/" + articleId))
                     .andExpect(method(HttpMethod.DELETE))
                     .andRespond(withSuccess());
 
             // When
-            sut.deleteArticle(articleId);
+            sut.deleteArticleComment(articleId);
 
             // Then
             server.verify();
         }
     }
-    private ArticleDto createArticleDto(String title, String content) {
-        return ArticleDto.of(
+    private ArticleCommentDto createArticleCommentDto(String content) {
+        return ArticleCommentDto.of(
                 1L
+                , 1L
                 , createUserAccountDto()
-                , title
-                , content
                 , null
+                , content
                 , LocalDateTime.now()
                 , "Jinwoo"
                 , LocalDateTime.now()


### PR DESCRIPTION
댓글 관리의 비즈니스 로직 및 테스트를 작성.
세부 내용은 구현이 안되어서 `main`이 아닌 `implementaion`브렌치에 머지
게시판 관리도 세부 내용은 구현이 안되있어서 `implementaion`에 했어야 됬으나 실수로 까먹고 main에 머지를 함

This closes #22 