### PR TITLE
기본 에러 페이지 구현

### DIFF
--- a/src/main/java/com/fastcampus/projectboardadmin/controller/WebErrorController.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/controller/WebErrorController.java
@@ -1,0 +1,30 @@
+package com.fastcampus.projectboardadmin.controller;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.boot.web.servlet.error.ErrorController;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+public class WebErrorController implements ErrorController {
+
+    @RequestMapping("/error")
+    public String error(
+            Model model
+            , HttpServletResponse response
+    ){
+        String viewName = "";
+        String responseSTATUS = Integer.toString(response.getStatus());
+
+        model.addAttribute("responseSTATUS", responseSTATUS);
+
+        if(responseSTATUS.substring(1).equals("4")) {
+            viewName = "error/4xx";
+        }else {
+            viewName = "error/5xx";
+        }
+
+        return viewName;
+    }
+}

--- a/src/main/resources/templates/error/4xx.html
+++ b/src/main/resources/templates/error/4xx.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head id="layout-head">
+    <meta charset="UTF-8">
+    <title>4xx 에러</title>
+</head>
+<body class="hold-transition sidebar-mini">
+    <div class="wrapper">
+        <header id="layout-header">헤더 삽입부</header>
+        <aside id="layout-left-aside">왼쪽 사이드 바 삽입부</aside>
+
+        <!-- Main content -->
+        <main class="content-wrapper">
+            <!-- Content Header (Page header) -->
+            <section class="content-header">
+                <div class="container-fluid">
+                    <div class="row mb-2">
+                        <div class="col-sm-6">
+                            <h1 id="main-header-title" class="m-0">Error Page</h1>
+                        </div>
+                        <div class="col-sm-6">
+                            <ol class="breadcrumb float-sm-right">
+                                <li class="breadcrumb-item"><a id="breadcrumb-home">Home</a></li>
+                                <li id="breadcrumb-current-page" class="breadcrumb-item active지">Error Page</li>
+                            </ol>
+                        </div>
+                    </div>
+                </div><!-- /.container-fluid -->
+            </section>
+
+            <!-- Main content -->
+            <section class="content">
+                <div class="error-page">
+                    <h2 id="error-status" class="headline text-warning">4XX</h2>
+
+                    <div class="error-content">
+                        <h3><i class="fas fa-exclamation-triangle text-warning"></i> Oops!</h3>
+
+                        <p>
+                            <span id="error-message">Something went wrong.</span>
+                        </p>
+                    </div>
+                    <!-- /.error-content -->
+                </div>
+                <!-- /.error-page -->
+            </section>
+            <!-- /.content -->
+        </main>
+        <!-- /.content -->
+
+        <aside id="layout-right-aside">오른쪽 사이드 바 삽입부</aside>
+        <footer id="layout-footer">푸터 삽입부</footer>
+    </div>
+
+    <!--/* REQUIRED SCRIPTS */-->
+    <script id="layout-scripts">/* 공통 스크립트 삽입부 */</script>
+
+    <!--/* 페이지 전용 스크립트 */-->
+</body>
+</html>

--- a/src/main/resources/templates/error/4xx.th.xml
+++ b/src/main/resources/templates/error/4xx.th.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<thlogic>
+    <attr sel="#layout-head" th:replace="layouts/layout-head :: common_head(~{::title}, (~{::link} ?: ~{}))" />
+    <attr sel="#layout-header" th:replace="layouts/layout-header :: header" />
+    <attr sel="#layout-left-aside" th:replace="layouts/layout-left-aside :: aside" />
+    <attr sel="#layout-right-aside" th:replace="layouts/layout-right-aside :: aside" />
+    <attr sel="#layout-footer" th:replace="layouts/layout-footer :: footer" />
+    <attr sel="#layout-scripts" th:replace="layouts/layout-scripts :: script" />
+
+    <attr sel="#main-header-title" th:text="'에러 페이지'" />
+    <attr sel="#breadcrumb-home" th:href="@{/}" th:text="'홈'" />
+    <attr sel="#breadcrumb-current-page" th:text="'에러 페이지'" />
+    <attr sel="#error-status" th:text="${responseSTATUS}" />
+    <attr sel="#error-message" th:text="'잘못된 호출입니다.'" />
+</thlogic>

--- a/src/main/resources/templates/error/5xx.html
+++ b/src/main/resources/templates/error/5xx.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head id="layout-head">
+    <meta charset="UTF-8">
+    <title>공통 템플릿</title>
+</head>
+<body class="hold-transition sidebar-mini">
+<div class="wrapper">
+    <header id="layout-header">헤더 삽입부</header>
+    <aside id="layout-left-aside">왼쪽 사이드 바 삽입부</aside>
+
+    <!-- Main content -->
+    <main class="content-wrapper">
+        <!-- Content Header (Page header) -->
+        <section class="content-header">
+            <div class="container-fluid">
+                <div class="row mb-2">
+                    <div class="col-sm-6">
+                        <h1 id="main-header-title" class="m-0">Error Page</h1>
+                    </div>
+                    <div class="col-sm-6">
+                        <ol class="breadcrumb float-sm-right">
+                            <li class="breadcrumb-item"><a id="breadcrumb-home">Home</a></li>
+                            <li id="breadcrumb-current-page" class="breadcrumb-item active지">Error Page</li>
+                        </ol>
+                    </div>
+                </div>
+            </div><!-- /.container-fluid -->
+        </section>
+
+        <!-- Main content -->
+        <section class="content">
+            <div class="error-page">
+                <h2 id="error-status" class="headline text-danger">5XX</h2>
+
+                <div class="error-content">
+                    <h3><i class="fas fa-exclamation-triangle text-danger"></i> Oops!</h3>
+
+                    <p>
+                        <span id="error-message">Something went wrong.</span>
+                    </p>
+                </div>
+                <!-- /.error-content -->
+            </div>
+            <!-- /.error-page -->
+        </section>
+        <!-- /.content -->
+    </main>
+    <!-- /.content -->
+
+    <aside id="layout-right-aside">오른쪽 사이드 바 삽입부</aside>
+    <footer id="layout-footer">푸터 삽입부</footer>
+</div>
+
+<!--/* REQUIRED SCRIPTS */-->
+<script id="layout-scripts">/* 공통 스크립트 삽입부 */</script>
+
+<!--/* 페이지 전용 스크립트 */-->
+</body>
+</html>

--- a/src/main/resources/templates/error/5xx.th.xml
+++ b/src/main/resources/templates/error/5xx.th.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<thlogic>
+    <attr sel="#layout-head" th:replace="layouts/layout-head :: common_head(~{::title}, (~{::link} ?: ~{}))" />
+    <attr sel="#layout-header" th:replace="layouts/layout-header :: header" />
+    <attr sel="#layout-left-aside" th:replace="layouts/layout-left-aside :: aside" />
+    <attr sel="#layout-right-aside" th:replace="layouts/layout-right-aside :: aside" />
+    <attr sel="#layout-footer" th:replace="layouts/layout-footer :: footer" />
+    <attr sel="#layout-scripts" th:replace="layouts/layout-scripts :: script" />
+
+    <attr sel="#main-header-title" th:text="'에러 페이지'" />
+    <attr sel="#breadcrumb-home" th:href="@{/}" th:text="'홈'" />
+    <attr sel="#breadcrumb-current-page" th:text="'에러 페이지'" />
+    <attr sel="#error-status" th:text="${responseSTATUS}" />
+    <attr sel="#error-message" th:text="'알 수 없는 에러가 발생했어요!'" />
+</thlogic>

--- a/src/main/resources/templates/layouts/layout-left-aside.th.xml
+++ b/src/main/resources/templates/layouts/layout-left-aside.th.xml
@@ -2,35 +2,35 @@
 <thlogic>
   <attr sel="#admin-logo-link" th:href="@{/}" />
 <!--  <attr sel="#user-profile" th:href="@{#}" sec:authorize="isAuthenticated()" sec:authentication="principal.nickname" />-->
-  <attr sel="#management-category" th:classappend="${requestURI.startsWith('/management')} ? 'active'" />
+  <attr sel="#management-category" th:classappend="${requestURI?.startsWith('/management')} ? 'active'" />
   <!--  <attr sel="#management-category" th:classappend="${#request.requestURI.startsWith('/management')} ? 'active'" />-->
   <attr
       sel="#article-management"
       th:href="@{/management/articles}"
-      th:classappend="${requestURI.equals('/management/articles')} ? 'active'"
+      th:classappend="${requestURI?.equals('/management/articles')} ? 'active'"
       />
 <!--      th:classappend="${#request.requestURI.equals('/management/articles')} ? 'active'"-->
 <!--  />-->
   <attr
       sel="#article-comment-management"
       th:href="@{/management/article-comments}"
-      th:classappend="${requestURI.equals('/management/article-comments')} ? 'active'"
+      th:classappend="${requestURI?.equals('/management/article-comments')} ? 'active'"
       />
 <!--      th:classappend="${#request.requestURI.equals('/management/article-comments')} ? 'active'"-->
 <!--  />-->
   <attr
       sel="#user-account-management"
       th:href="@{/management/user-accounts}"
-      th:classappend="${requestURI.equals('/management/user-accounts')} ? 'active'"
+      th:classappend="${requestURI?.equals('/management/user-accounts')} ? 'active'"
       />
 <!--      th:classappend="${#request.requestURI.equals('/management/user-accounts')} ? 'active'"-->
 <!--  />-->
-  <attr sel="#admin-category" th:classappend="${requestURI.startsWith('/admin')} ? 'active'" />
+  <attr sel="#admin-category" th:classappend="${requestURI?.startsWith('/admin')} ? 'active'" />
 <!--  <attr sel="#admin-category" th:classappend="${#request.requestURI.startsWith('/admin')} ? 'active'" />-->
   <attr
       sel="#admin-members"
       th:href="@{/admin/members}"
-      th:classappend="${requestURI.equals('/admin/members')} ? 'active'"
+      th:classappend="${requestURI?.equals('/admin/members')} ? 'active'"
       />
 <!--      th:classappend="${#request.requestURI.equals('/admin/members')} ? 'active'"-->
 <!--  />-->


### PR DESCRIPTION
스프링 부트에서 지원하는 에러 페이지 등록 방법을 이용하여
간단하게 4xx, 5xx 에러에 각각 대응하는 에러 페이지를 등록

* 스프링3.x 부터는 타임리프에서 `#response`를 보안상 사용을 못하게 변경이 되어서 `WebErrorController` 를 추가로 만들어서 response.getStatus() 를 직접 보내주는 방식을 사용하여 웹 화면에 보여줄 수 있도록 함.

This closes #33 